### PR TITLE
add new window override

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,6 +6,9 @@
   "chrome_url_overrides": {
     "newtab": "index.html"
   },
+  "chrome_settings_overrides": {
+    "homepage": "index.html"
+  },
   "permissions": ["bookmarks"],
   "optional_permissions": ["tabs"],
   "icons": {


### PR DESCRIPTION
Closes #13 by adding `chrome_settings_overrides` to the manifest.json

Documentation with Version Support Reference:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a homepage override for the browser extension, directing users to a specified HTML file.

- **Documentation**
	- Updated the manifest to include new settings for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->